### PR TITLE
Remove caching from provider data loading

### DIFF
--- a/provider_utils.py
+++ b/provider_utils.py
@@ -5,11 +5,9 @@ import io
 from docx import Document
 import re
 from pathlib import Path
-from functools import lru_cache
 
 
 # --- Data Loading ---
-@lru_cache(maxsize=1)
 def load_provider_data(filepath: str) -> pd.DataFrame:
     """Load and preprocess provider data from Excel, CSV, Feather, or Parquet."""
 
@@ -30,6 +28,7 @@ def load_provider_data(filepath: str) -> pd.DataFrame:
         raise ValueError(f"Unsupported file type: {suffix}")
 
     df.columns = [col.strip() for col in df.columns]
+    df = df.drop(columns='Preference', errors='ignore')
     df['Zip'] = df['Zip'].apply(lambda x: str(x) if pd.notnull(x) else '')
     df['Referral Count'] = pd.to_numeric(df.get('Referral Count'), errors='coerce')
     df['Full Address'] = (


### PR DESCRIPTION
## Summary
- Drop obsolete 'Preference' column when loading provider data
- Remove `lru_cache` to avoid stale provider data

## Testing
- `python -m py_compile provider_utils.py app.py`
- `pytest -q`
- `streamlit run app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a79596c5f8832bac38260b80e3ace6